### PR TITLE
freshworks-domain-authentication Template

### DIFF
--- a/freshworks.com.domain-authentication.json
+++ b/freshworks.com.domain-authentication.json
@@ -6,71 +6,72 @@
   "logoUrl": "https://dam.freshworks.com/m/1d230ee78c07681a/original/headerLogoLight.webp",
   "version": 1,
   "syncPubKeyDomain": "freshworks.com",
-"variableDescription": "Self explanatory in the variable names",
-"description": "CNAME records are utilized for domain verification, enabling Freshworks to authenticate emails sent on behalf of customers. Additionally, DKIM records are employed to further authenticate these emails.",
+  "variableDescription": "Self explanatory in the variable names",
+  "description": "CNAME records are utilized for domain verification, enabling Freshworks to authenticate emails sent on behalf of customers. Additionally, DKIM records are employed to further authenticate these emails.",
+  "hostRequired": true,
   "records": [
     {
       "groupId": "dkim1",
-      "host": "%cname_host%",
+      "host": "@",
       "type": "CNAME",
       "pointsTo": "%cname_pointsTo%",
-      "ttl": 60
+      "ttl": 900
     },
     {
       "groupId": "dkim2",
-      "host": "%cname_host%",
+      "host": "@",
       "type": "CNAME",
       "pointsTo": "%cname_pointsTo%",
-      "ttl": 60
+      "ttl": 900
     },
     {
       "groupId": "dkim3",
-      "host": "%cname_host%",
+      "host": "@",
       "type": "CNAME",
       "pointsTo": "%cname_pointsTo%",
-      "ttl": 60
+      "ttl": 900
     },
     {
       "groupId": "dkim4",
-      "host": "%cname_host%",
+      "host": "@",
       "type": "CNAME",
       "pointsTo": "%cname_pointsTo%",
-      "ttl": 60
+      "ttl": 900
     },
     {
       "groupId": "spfmx",
-      "host": "%cname_host%",
+      "host": "@",
       "type": "CNAME",
       "pointsTo": "%cname_pointsTo%",
-      "ttl": 60
+      "ttl": 900
     },
     {
       "groupId": "tracking1",
-      "host": "%cname_host%",
+      "host": "@",
       "type": "CNAME",
       "pointsTo": "%cname_pointsTo%",
-      "ttl": 60
+      "ttl": 900
     },
     {
       "groupId": "tracking2",
-      "host": "%cname_host%",
+      "host": "@",
       "type": "CNAME",
       "pointsTo": "%cname_pointsTo%",
-      "ttl": 60
+      "ttl": 900
     },
     {
       "groupId": "tracking3",
-      "host": "%cname_host%",
+      "host": "@",
       "type": "CNAME",
       "pointsTo": "%cname_pointsTo%",
-      "ttl": 60
+      "ttl": 900
     },
     {
       "groupId": "tracking4",
-      "host": "%cname_host%",
+      "host": "@",
       "type": "CNAME",
       "pointsTo": "%cname_pointsTo%",
-      "ttl": 60
+      "ttl": 900
     }
   ]
 }

--- a/freshworks.com.domain-authentication.json
+++ b/freshworks.com.domain-authentication.json
@@ -6,71 +6,71 @@
   "logoUrl": "https://dam.freshworks.com/m/1d230ee78c07681a/original/headerLogoLight.webp",
   "version": 1,
   "syncPubKeyDomain": "freshworks.com",
-  "variableDescription": "Self explanatory in the variable names",
-  "description": "CNAME records are utilized for domain verification, enabling Freshworks to authenticate emails sent on behalf of customers. Additionally, DKIM records are employed to further authenticate these emails.",
+"variableDescription": "Self explanatory in the variable names",
+"description": "CNAME records are utilized for domain verification, enabling Freshworks to authenticate emails sent on behalf of customers. Additionally, DKIM records are employed to further authenticate these emails.",
   "records": [
     {
       "groupId": "dkim1",
       "host": "%cname_host%",
       "type": "CNAME",
-      "value": "%cname_value%",
-      "ttl": 900
+      "pointsTo": "%cname_pointsTo%",
+      "ttl": 60
     },
     {
       "groupId": "dkim2",
       "host": "%cname_host%",
       "type": "CNAME",
-      "value": "%cname_value%",
-      "ttl": 900
+      "pointsTo": "%cname_pointsTo%",
+      "ttl": 60
     },
     {
       "groupId": "dkim3",
       "host": "%cname_host%",
       "type": "CNAME",
-      "value": "%cname_value%",
-      "ttl": 900
+      "pointsTo": "%cname_pointsTo%",
+      "ttl": 60
     },
     {
       "groupId": "dkim4",
       "host": "%cname_host%",
       "type": "CNAME",
-      "value": "%cname_value%",
-      "ttl": 900
+      "pointsTo": "%cname_pointsTo%",
+      "ttl": 60
     },
     {
       "groupId": "spfmx",
       "host": "%cname_host%",
       "type": "CNAME",
-      "value": "%cname_value%",
-      "ttl": 900
+      "pointsTo": "%cname_pointsTo%",
+      "ttl": 60
     },
     {
       "groupId": "tracking1",
       "host": "%cname_host%",
       "type": "CNAME",
-      "value": "%cname_value%",
-      "ttl": 900
+      "pointsTo": "%cname_pointsTo%",
+      "ttl": 60
     },
     {
       "groupId": "tracking2",
       "host": "%cname_host%",
       "type": "CNAME",
-      "value": "%cname_value%",
-      "ttl": 900
+      "pointsTo": "%cname_pointsTo%",
+      "ttl": 60
     },
     {
       "groupId": "tracking3",
       "host": "%cname_host%",
       "type": "CNAME",
-      "value": "%cname_value%",
-      "ttl": 900
+      "pointsTo": "%cname_pointsTo%",
+      "ttl": 60
     },
     {
       "groupId": "tracking4",
       "host": "%cname_host%",
       "type": "CNAME",
-      "value": "%cname_value%",
-      "ttl": 900
+      "pointsTo": "%cname_pointsTo%",
+      "ttl": 60
     }
   ]
 }

--- a/freshworks.com.domain-authentication.json
+++ b/freshworks.com.domain-authentication.json
@@ -1,0 +1,76 @@
+{
+  "providerId": "freshworks.com",
+  "providerName": "Freshworks",
+  "serviceId": "domain-authentication",
+  "serviceName": "Freshworks",
+  "logoUrl": "https://dam.freshworks.com/m/1d230ee78c07681a/original/headerLogoLight.webp",
+  "version": 1,
+  "syncPubKeyDomain": "freshworks.com",
+  "variableDescription": "Self explanatory in the variable names",
+  "description": "CNAME records are utilized for domain verification, enabling Freshworks to authenticate emails sent on behalf of customers. Additionally, DKIM records are employed to further authenticate these emails.",
+  "records": [
+    {
+      "groupId": "dkim1",
+      "host": "%cname_host%",
+      "type": "CNAME",
+      "value": "%cname_value%",
+      "ttl": 900
+    },
+    {
+      "groupId": "dkim2",
+      "host": "%cname_host%",
+      "type": "CNAME",
+      "value": "%cname_value%",
+      "ttl": 900
+    },
+    {
+      "groupId": "dkim3",
+      "host": "%cname_host%",
+      "type": "CNAME",
+      "value": "%cname_value%",
+      "ttl": 900
+    },
+    {
+      "groupId": "dkim4",
+      "host": "%cname_host%",
+      "type": "CNAME",
+      "value": "%cname_value%",
+      "ttl": 900
+    },
+    {
+      "groupId": "spfmx",
+      "host": "%cname_host%",
+      "type": "CNAME",
+      "value": "%cname_value%",
+      "ttl": 900
+    },
+    {
+      "groupId": "tracking1",
+      "host": "%cname_host%",
+      "type": "CNAME",
+      "value": "%cname_value%",
+      "ttl": 900
+    },
+    {
+      "groupId": "tracking2",
+      "host": "%cname_host%",
+      "type": "CNAME",
+      "value": "%cname_value%",
+      "ttl": 900
+    },
+    {
+      "groupId": "tracking3",
+      "host": "%cname_host%",
+      "type": "CNAME",
+      "value": "%cname_value%",
+      "ttl": 900
+    },
+    {
+      "groupId": "tracking4",
+      "host": "%cname_host%",
+      "type": "CNAME",
+      "value": "%cname_value%",
+      "ttl": 900
+    }
+  ]
+}


### PR DESCRIPTION
CNAME records are utilized for domain verification, enabling Freshworks to authenticate emails sent on behalf of customers. Additionally, DKIM records are employed to further authenticate these emails.